### PR TITLE
Add configurations sections to CORE

### DIFF
--- a/core/manifest.json
+++ b/core/manifest.json
@@ -2,21 +2,154 @@
   "manifestVersion": 1,
   "meta": {
     "name": "Dogecoin Core",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "logoPath": "logo.png",
     "shortDescription": "Run a full core node on your dogebox",
-    "longDescription": "This pup launches and configures a full Dogecoin Core node on your dogebox, allowing you to sync the blockchain and contribute to the network.",
+    "longDescription": "This pup launches and configures a full Dogecoin Core node on your dogebox, allowing you to sync the blockchain and contribute to the network.\n\nIMPORTANT: After saving configuration changes, you must DISABLE and then ENABLE the CORE pup to apply the new settings.",
     "upstreamVersions": {
       "Core": "v1.14.9"
     }
   },
   "config": {
-    "sections": null
+    "sections": [
+      {
+        "name": "Node Features",
+        "description": "Enable/disable node features and indexing. After saving changes below, disable and re-enable this pup to apply settings.",
+        "fields": [
+          {
+            "name": "ENABLE_TXINDEX",
+            "label": "Enable Transaction Index",
+            "type": "toggle",
+            "default": true
+          }
+        ]
+      },
+      {
+        "name": "RPC",
+        "description": "RPC server configuration",
+        "fields": [
+          {
+            "name": "ENABLE_RPC",
+            "label": "Enable RPC Server",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "name": "RPC_USERNAME",
+            "label": "RPC Username",
+            "type": "text",
+            "default": "dogebox_core_pup_temporary_static_username"
+          },
+          {
+            "name": "RPC_PASSWORD",
+            "label": "RPC Password",
+            "type": "password",
+            "default": "dogebox_core_pup_temporary_static_password"
+          },
+          {
+            "name": "RPC_PORT",
+            "label": "RPC Port",
+            "type": "text",
+            "default": "22555"
+          },
+          {
+            "name": "RPC_ALLOWED_IPS",
+            "label": "RPC Allowed IPs (comma-separated)",
+            "type": "text",
+            "default": "0.0.0.0/0"
+          },
+          {
+            "name": "RPCBIND_ADDRESS",
+            "label": "RPC Bind Address (optional, overrides auto)",
+            "type": "text",
+            "default": ""
+          }
+        ]
+      },
+      {
+        "name": "Network",
+        "description": "P2P network and connection settings",
+        "fields": [
+          {
+            "name": "PORT",
+            "label": "P2P Port",
+            "type": "text",
+            "default": "22556"
+          },
+          {
+            "name": "MAXCONNECTIONS",
+            "label": "Max Connections",
+            "type": "text",
+            "default": "125"
+          }
+        ]
+      },
+      {
+        "name": "ZMQ",
+        "description": "ZMQ message queue endpoints",
+        "fields": [
+          {
+            "name": "ENABLE_ZMQ",
+            "label": "Enable ZMQ",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "name": "ZMQ_PUBHASHTX",
+            "label": "ZMQ Publish Hash TX",
+            "type": "text",
+            "default": ""
+          },
+          {
+            "name": "ZMQ_PUBRAWBLOCK",
+            "label": "ZMQ Publish Raw Block",
+            "type": "text",
+            "default": ""
+          },
+          {
+            "name": "ZMQ_PUBRAWTX",
+            "label": "ZMQ Publish Raw TX",
+            "type": "text",
+            "default": ""
+          }
+        ]
+      },
+      {
+        "name": "Advanced",
+        "description": "Advanced performance and debugging options",
+        "fields": [
+          {
+            "name": "PRUNE",
+            "label": "Prune (MB, 0 to disable)",
+            "type": "text",
+            "default": "0"
+          },
+          {
+            "name": "DBCACHE",
+            "label": "Database Cache (MB)",
+            "type": "text",
+            "default": "300"
+          },
+          {
+            "name": "DEBUG",
+            "label": "Debug Level",
+            "type": "text",
+            "default": ""
+          },
+          {
+            "name": "UACOMMENT",
+            "label": "User Agent Comment",
+            "type": "text",
+            "default": ""
+          }
+        ]
+      }
+    ]
   },
   "container": {
     "build": {
       "nixFile": "pup.nix",
-      "nixFileSha256": "3f903cfaef48e5416b47719f8103fba7a9498e41e6137f6c89c225111a7bd6bf"
+      "nixFileSha256": "ZRyZ1ecKKRe0+UR5Jaq6kazke9/nJvL9yS1i4F5ajak="
     },
     "services": [
       {
@@ -56,21 +189,12 @@
       },
       {
         "name": "rpc",
-        "type": "http",
-        "port": 22555,
-        "interfaces": [
-          "core-rpc"
-        ],
-        "listenOnHost": false
-      },
-      {
-        "name": "rpc-tcp",
         "type": "tcp",
         "port": 22555,
         "interfaces": [
           "core-rpc"
         ],
-        "listenOnHost": false
+        "listenOnHost": true
       },
       {
         "name": "zmq",

--- a/core/pup.nix
+++ b/core/pup.nix
@@ -14,27 +14,120 @@ let
 
   dogecoind = pkgs.writeScriptBin "run.sh" ''
     #!${pkgs.stdenv.shell}
-    if [ ! -f /storage/rpcuser.txt ] || [ ! -f /storage/rpcpassword.txt ]; then
-        RPCUSER=dogebox_core_pup_temporary_static_username
-        RPCPASS=dogebox_core_pup_temporary_static_password
 
-        echo "$RPCUSER" > /storage/rpcuser.txt
-        echo "$RPCPASS" > /storage/rpcpassword.txt
+    # RPC Configuration (from manifest config or defaults)
+    ENABLE_RPC="''${ENABLE_RPC:-1}"
+    RPCUSER="''${RPC_USERNAME:-dogebox_core_pup_temporary_static_username}"
+    RPCPASS="''${RPC_PASSWORD:-dogebox_core_pup_temporary_static_password}"
+    RPC_PORT="''${RPC_PORT:-22555}"
+    RPC_ALLOWED_IPS="''${RPC_ALLOWED_IPS:-0.0.0.0/0}"
+
+    # Node Features (from manifest config or defaults)
+    ENABLE_TXINDEX="''${ENABLE_TXINDEX:-1}"
+    ENABLE_ZMQ="''${ENABLE_ZMQ:-1}"
+
+    # Network Configuration (from manifest config or defaults)
+    P2P_PORT="''${PORT:-22556}"
+    MAXCONNECTIONS="''${MAXCONNECTIONS:-125}"
+
+    # Advanced Configuration (from manifest config or defaults)
+    PRUNE="''${PRUNE:-0}"
+    DBCACHE="''${DBCACHE:-300}"
+    DEBUG="''${DEBUG:-}"
+
+    # User Agent Comment
+    UACOMMENT="''${UACOMMENT:-}"
+
+    # ZMQ Advanced (custom endpoints)
+    ZMQ_PUBHASHTX="''${ZMQ_PUBHASHTX:-}"
+    ZMQ_PUBRAWBLOCK="''${ZMQ_PUBRAWBLOCK:-}"
+    ZMQ_PUBRAWTX="''${ZMQ_PUBRAWTX:-}"
+
+    # Wallet Features (disabled by default - cannot be enabled)
+    ZAPWALLETTXES="''${ZAPWALLETTXES:-0}"
+
+    # RPC Network Binding
+    RPCBIND_ADDRESS="''${RPCBIND_ADDRESS:-}"
+
+    # Persist RPC credentials to storage for monitor/logger access
+    echo "$RPCUSER" > /storage/rpcuser.txt
+    echo "$RPCPASS" > /storage/rpcpassword.txt
+
+    # Build dogecoind arguments
+    if [ "$ENABLE_RPC" = "1" ] || [ "$ENABLE_RPC" = "true" ]; then
+      DOGECOIND_ARGS="-port=$P2P_PORT -datadir=${storageDirectory} -rpc=1 -rpcuser=$RPCUSER -rpcpassword=$RPCPASS -rpcport=$RPC_PORT"
     else
-        RPCUSER=$(cat /storage/rpcuser.txt)
-        RPCPASS=$(cat /storage/rpcpassword.txt)
+      DOGECOIND_ARGS="-port=$P2P_PORT -datadir=${storageDirectory} -rpc=0"
     fi
-    
-    ${dogecoind_bin}/bin/dogecoind \
-      -port=22556 \
-      -datadir=${storageDirectory} \
-      -rpc=1 \
-      -rpcuser=$RPCUSER \
-      -rpcpassword=$RPCPASS \
-      -rpcbind=$DBX_PUP_IP \
-      -rpcport=22555 \
-      -rpcallowip=0.0.0.0/0 \
-      -zmqpubhashblock=tcp://0.0.0.0:28332
+
+    # Add RPC configuration only if RPC is enabled
+    if [ "$ENABLE_RPC" = "1" ] || [ "$ENABLE_RPC" = "true" ]; then
+      # Add RPC bind address (use custom if provided, otherwise use container IP)
+      if [ ! -z "$RPCBIND_ADDRESS" ]; then
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -rpcbind=$RPCBIND_ADDRESS"
+      else
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -rpcbind=$DBX_PUP_IP"
+      fi
+
+      # Add RPC allowed IPs (comma-separated to individual -rpcallowip flags)
+      IFS=',' read -ra IPS <<< "$RPC_ALLOWED_IPS"
+      for IP in "''${IPS[@]}"; do
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -rpcallowip=$(echo $IP | xargs)"
+      done
+    fi
+
+    # Add transaction index if enabled
+    if [ "$ENABLE_TXINDEX" = "1" ] || [ "$ENABLE_TXINDEX" = "true" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -txindex=1"
+    fi
+
+    # Add ZMQ if enabled
+    if [ "$ENABLE_ZMQ" = "1" ] || [ "$ENABLE_ZMQ" = "true" ]; then
+      if [ ! -z "$ZMQ_PUBHASHBLOCK" ]; then
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -zmqpubhashblock=$ZMQ_PUBHASHBLOCK"
+      else
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -zmqpubhashblock=tcp://$DBX_PUP_IP:28332"
+      fi
+
+      # Add optional ZMQ endpoints if specified
+      if [ ! -z "$ZMQ_PUBHASHTX" ]; then
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -zmqpubhashtx=$ZMQ_PUBHASHTX"
+      fi
+      if [ ! -z "$ZMQ_PUBRAWBLOCK" ]; then
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -zmqpubrawblock=$ZMQ_PUBRAWBLOCK"
+      fi
+      if [ ! -z "$ZMQ_PUBRAWTX" ]; then
+        DOGECOIND_ARGS="$DOGECOIND_ARGS -zmqpubrawtx=$ZMQ_PUBRAWTX"
+      fi
+    fi
+
+    # Add user agent comment if specified
+    if [ ! -z "$UACOMMENT" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -uacomment=$UACOMMENT"
+    fi
+
+    # Add max connections if not default
+    if [ ! -z "$MAXCONNECTIONS" ] && [ "$MAXCONNECTIONS" != "125" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -maxconnections=$MAXCONNECTIONS"
+    fi
+
+    # Add prune if enabled (value in MB, 0 = disabled)
+    if [ ! -z "$PRUNE" ] && [ "$PRUNE" != "0" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -prune=$PRUNE"
+    fi
+
+    # Add database cache if not default
+    if [ ! -z "$DBCACHE" ] && [ "$DBCACHE" != "300" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -dbcache=$DBCACHE"
+    fi
+
+    # Add debug level if specified
+    if [ ! -z "$DEBUG" ]; then
+      DOGECOIND_ARGS="$DOGECOIND_ARGS -debug=$DEBUG"
+    fi
+
+    # Run dogecoind with constructed arguments
+    ${dogecoind_bin}/bin/dogecoind $DOGECOIND_ARGS
   '';
 
   monitor = pkgs.buildGoModule {


### PR DESCRIPTION
- Add configurations sections: Node Features, RPC, Network, ZMQ, Advanced
- Implement dynamic configuration handling in pup.nix script
- Enable Transaction Index, RPC Server, ZMQ, and Advanced options configurability
- Hard disable wallet (disableWallet = true) with no enable option
- Simplify exposes section by removing redundant rpc-tcp entry
- Update version to 0.0.11
- Update pup.nix hash to ZRyZ1ecKKRe0+UR5Jaq6kazke9/nJvL9yS1i4F5ajak=
- Add note about disabling/re-enabling pup after configuration changes"