### PR TITLE
Added explicit go = pkgs.go_1_24; parameter to buildGoModule

### DIFF
--- a/gigawallet/manifest.json
+++ b/gigawallet/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "meta": {
     "name": "Gigawallet",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "logoPath": "logo.png",
     "shortDescription": "A Dogecoin payment gateway for business apps",
     "longDescription": "Dogecoin GigaWallet is a backend service which provides a convenient integration API for platforms such as online shops, exchanges, social media platforms etc, to transact Dogecoin on behalf of their users.",
@@ -16,7 +16,7 @@
   "container": {
     "build": {
       "nixFile": "pup.nix",
-      "nixFileSha256": "7d0e226f3df9908409c8d9de7ebf9d0f573df59ba8b3dc8565e0a73c7b4ec77e"
+      "nixFileSha256": "58cd9d931f78925622e505c6c36c0a1f865427c174c695186f33f32fd1eae33e"
     },
     "services": [
       {

--- a/gigawallet/pup.nix
+++ b/gigawallet/pup.nix
@@ -4,6 +4,7 @@ let
   gigawallet_bin = pkgs.buildGoModule {
   pname = "gigawallet";
   version = "1.0.1";
+  go = pkgs.go_1_24;
 
   src = pkgs.fetchgit {
     url = "https://github.com/dogecoinfoundation/gigawallet.git";
@@ -14,7 +15,6 @@ let
   vendorHash = "sha256-mW5SStSabjWIlLWarI0OfyCTRWRQnEbk2BXabJCJ2h4";
 
   nativeBuildInputs = [
-    pkgs.go_1_24
     pkgs.pkg-config
   ];
 


### PR DESCRIPTION
Added explicit go = pkgs.go_1_24; parameter to buildGoModule to ensure Go 1.24 is used as the compiler Removed pkgs.go_1_24 from nativeBuildInputs (now handled by the go parameter) This prevents the build system from defaulting to the end-of-life Go 1.23